### PR TITLE
Optimize haptic feedback in some phones

### DIFF
--- a/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ChartFragment.kt
+++ b/app/src/main/kotlin/com/absinthe/libchecker/ui/fragment/statistics/ChartFragment.kt
@@ -304,7 +304,7 @@ class ChartFragment : BaseFragment<FragmentPieChartBinding>(R.layout.fragment_pi
         if (h == null) return
         if (mDialog != null && mDialog!!.isShowing()) return
 
-        chartView.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+        chartView.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
 
         var dialogTitle = ""
         var item: List<LCItem> = emptyList()


### PR DESCRIPTION
HapticFeedbackConstants.CONFIRM perform better than HapticFeedbackConstants.CLOCK_TICK in some roms. For example,  my phone  system is MIUI 12.5, CLOCK_TICK  will perform as a LONG  AND POWERFUI vibrate , it feels too bad. Maybe CONFIRM is more suitable for the haptic feedback.